### PR TITLE
Move build and test dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "homepage": "https://github.com/sfarthin/crop-rotate-and-sample-in-browser",
   "dependencies": {
-    "async": "^0.9.0",
-    "underscore": "^1.7.0"
+    "async": "^2.4.1",
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "body-parser": "^1.4.3",
@@ -85,7 +85,6 @@
     "karma-chrome-launcher": "^0.2.0",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.1.4",
-    "lodash": "^3.10.0",
     "resemblejs": "^1.3.1",
     "uglifyify": "^2.5.0",
     "vinyl-source-stream": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -64,22 +64,21 @@
   },
   "homepage": "https://github.com/sfarthin/crop-rotate-and-sample-in-browser",
   "dependencies": {
-    "express": "^4.6.1",
-    "gulp-jade": "^0.6.1",
-    "gulp-less": "^1.3.1",
-    "gulp": "^3.8.5",
-    "browserify": "^4.2.0",
-    "vinyl-source-stream": "^0.1.1",
-    "uglifyify": "^2.5.0",
-    "gcs-signed-urls": "0.0.1",
-    "jade": "^1.4.2",
-    "body-parser": "^1.4.3",
-    "browserify-shim": "^3.6.0",
     "async": "^0.9.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
+    "body-parser": "^1.4.3",
+    "browserify": "^4.2.0",
+    "browserify-shim": "^3.6.0",
     "chromedriver": "^2.10.0-1",
+    "express": "^4.6.1",
+    "gcs-signed-urls": "0.0.1",
+    "gulp": "^3.8.5",
+    "gulp-jade": "^0.6.1",
+    "gulp-less": "^1.3.1",
+    "jade": "^1.4.2",
+    "jasmine-core": "^2.6.3",
     "jasmine-reporters": "^2.0.3",
     "karma": "^0.12.22",
     "karma-browserify": "^0.2.1",
@@ -87,6 +86,8 @@
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.1.4",
     "lodash": "^3.10.0",
-    "resemblejs": "^1.1.2"
+    "resemblejs": "^1.3.1",
+    "uglifyify": "^2.5.0",
+    "vinyl-source-stream": "^0.1.1"
   }
 }

--- a/src/methods.js
+++ b/src/methods.js
@@ -2,7 +2,10 @@ var EXIF = require("./exif"),
 	BinaryFile = require("./binaryFile"),
 	toBlob = require("./canvas-to-blob"),
 	async = require("async"),
-	_ = require("underscore");
+	each = require("lodash/each"),
+	extend = require("lodash/extend"),
+	union = require("lodash/union"),
+	values = require("lodash/values");
 
 
 var staticMethods = {
@@ -266,19 +269,19 @@ function ImageMethodConstructor(canvas) {
 
 // Make our static methods Chainable
 delete ImageMethodConstructor.prototype.getCanvasFromUrl;
-_.each(staticMethods, function(func, key) {
+each(staticMethods, function(func, key) {
 	ImageMethodConstructor.prototype[key] = function() {
-		this.canvas = func.apply(this, [this.canvas].concat(_.values(arguments)));
+		this.canvas = func.apply(this, [this.canvas].concat(values(arguments)));
 		return this;
 	};
 });
 
 // Lets overwrite these non chainable methods
 ImageMethodConstructor.prototype.toBlob = function() {
-	return staticMethods.toBlob.apply(this, _.union([this.canvas], arguments));
+	return staticMethods.toBlob.apply(this, union([this.canvas], arguments));
 };
 
 // TODO Lets add a wrapper for Camanjs (http://camanjs.com/) methods.
 
 
-module.exports = window.ImageMethods = _.extend(ImageMethodConstructor, staticMethods);
+module.exports = window.ImageMethods = extend(ImageMethodConstructor, staticMethods);

--- a/test/methods.spec.js
+++ b/test/methods.spec.js
@@ -1,5 +1,5 @@
 var ImageMethods = require("../src/methods.js"),
-	resemble = require("resemblejs").resemble,
+	resemble = require("resemblejs"),
 	async = require("async"),
 	_ = require("lodash");
 


### PR DESCRIPTION
Closes #4

This way users of this package won't install unnecessary dependencies.
Also replaced `underscore` with `lodash` since it was also present, to reduce amount of deps.